### PR TITLE
Add dontAutomergeCIDependencies renovate preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,26 @@ renovate.json
 ```
 {
   "extends": [
+    "config:base",
+    "github>CondeNast/renovate-config:groupMinorUpdates(dependencies)"
     "github>CondeNast/renovate-config:forceCondenastUpdates",
     "github>CondeNast/renovate-config:automergeMinor",
     "github>CondeNast/renovate-config:condenastStabilityDays",
     "github>CondeNast/renovate-config:dontAutomergeMajor(help wanted)",
     "github>CondeNast/renovate-config:dontAutomergeNode(help wanted)",
     "github>CondeNast/renovate-config:dontAutomergeTestFrameworks(help wanted)",
-    "github>CondeNast/renovate-config:groupMinorUpdates(dependencies)"
+    "github>CondeNast/renovate-config:dontAutomergeCIDependencies(help wanted)",
+  ]
+}
+```
+
+Alternatively:
+
+```
+{
+  "extends": [
+    "config:base",
+    "github>CondeNast/renovate-config"
   ]
 }
 ```
@@ -41,6 +54,10 @@ Disables automerge for Node.js upgrades and also groups them together. This is h
 ### `dontAutomergeTestFrameworks`
 
 Disables automerge for testing frameworks. Upgrades to testing frameworks need to be validated manually to avoid false positive results.
+
+### `dontAutomergeCIDependencies`
+
+Disables automerge for CI pipeline dependencies. Upgrades to CI dependencies need to be validated manually to avoid false positive results. This also helps if you want to compile your CI configuration locally and keep the generated output in source control without Renovate automatically making changes to it.
 
 ### `forceCondenastUpdates`
 

--- a/dontAutomergeCIDependencies.json
+++ b/dontAutomergeCIDependencies.json
@@ -1,0 +1,48 @@
+{
+  "description": "Disables automerge for CI pipeline dependencies.",
+  "packageRules": [
+    {
+      "managers": ["circleci"],
+      "patch": {
+        "groupName": "CI dependencies",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      },
+      "minor": {
+        "groupName": "CI dependencies",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      },
+      "major": {
+        "groupName": "CI dependencies major version",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      },
+      "pin": {
+        "groupName": "CI dependencies",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      },
+      "digest": {
+        "groupName": "CI dependencies",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      },
+      "lockFileMaintenance": {
+        "groupName": "CI dependencies",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      },
+      "rollback": {
+        "groupName": "CI dependencies",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      },
+      "bump": {
+        "groupName": "CI dependencies",
+        "automerge": false,
+        "labels": ["{{arg0}}"]
+      }
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,12 @@
 {
   "extends": [
+    "github>CondeNast/renovate-config:groupMinorUpdates(dependencies)",
     "github>CondeNast/renovate-config:forceCondenastUpdates",
     "github>CondeNast/renovate-config:automergeMinor",
     "github>CondeNast/renovate-config:condenastStabilityDays",
     "github>CondeNast/renovate-config:dontAutomergeMajor(help wanted)",
     "github>CondeNast/renovate-config:dontAutomergeNode(help wanted)",
     "github>CondeNast/renovate-config:dontAutomergeTestFrameworks(help wanted)",
-    "github>CondeNast/renovate-config:groupMinorUpdates(dependencies)"
+    "github>CondeNast/renovate-config:dontAutomergeCIDependencies(help wanted)"
   ]
 }


### PR DESCRIPTION
This is a fix for https://github.com/CondeNast/rocket/pull/7826

Quote from README:

> Disables automerge for CI pipeline dependencies. Upgrades to CI dependencies need to be validated manually to avoid false positive results. This also helps if you want to compile your CI configuration locally and keep the generated output in source control without Renovate automatically making changes to it.