### PR TITLE
Delay opening Node.js update PR for 3 days

### DIFF
--- a/groupNodeUpdates.json
+++ b/groupNodeUpdates.json
@@ -3,6 +3,8 @@
   "packageRules": [
     {
       "extends": ["github>CondeNast/renovate-config:node"],
+      "stabilityDays": 3,
+      "prCreation": "not-pending"
       "groupName": "Node.js",
       "patch": {
         "groupName": "Node.js"

--- a/groupNodeUpdates.json
+++ b/groupNodeUpdates.json
@@ -4,7 +4,7 @@
     {
       "extends": ["github>CondeNast/renovate-config:node"],
       "stabilityDays": 3,
-      "prCreation": "not-pending"
+      "prCreation": "not-pending",
       "groupName": "Node.js",
       "patch": {
         "groupName": "Node.js"


### PR DESCRIPTION
This delays Renovate opening PRs to upgrade Node.js to the latest
version by 3 days. This is helpful if you have multiple places where the
Node.js version is set (e.g. multiple different Docker base images) and
these don't always get released in sync with each other, so you have to
wait for all of the new releases before you can merge them.