### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:base",
     "github>CondeNast/renovate-config:groupMinorUpdates(dependencies)",
-    "github>CondeNast/renovate-config:groupNodeUpdates",
-    "github>CondeNast/renovate-config:forceCondenastUpdates"
+    "github>CondeNast/renovate-config:groupNodeUpdates"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,8 @@
 {
   "extends": [
+    "config:base",
     "github>CondeNast/renovate-config:groupMinorUpdates(dependencies)",
-    "github>CondeNast/renovate-config:forceCondenastUpdates",
-    "github>CondeNast/renovate-config:automergeMinor",
-    "github>CondeNast/renovate-config:condenastStabilityDays",
-    "github>CondeNast/renovate-config:dontAutomergeMajor(help wanted)",
-    "github>CondeNast/renovate-config:dontAutomergeNode(help wanted)",
-    "github>CondeNast/renovate-config:dontAutomergeTestFrameworks(help wanted)",
-    "github>CondeNast/renovate-config:dontAutomergeCIDependencies(help wanted)"
+    "github>CondeNast/renovate-config:groupNodeUpdates",
+    "github>CondeNast/renovate-config:forceCondenastUpdates"
   ]
 }


### PR DESCRIPTION
This preset is not currently fit for purpose because it's overly opinionated and does too much magic stuff. This preset is also the default preset whenever a new repo is added to the org – (I didn't realise this was the case before now).

It's currently only being used in one code repo, [CondeNast/albatross](https://github.com/CondeNast/albatross/blob/26e49349f7bb33f4de20008ae11340648e4c4469/renovate.json), so these changes will not have a broad impact, but it makes sense to have a more reasonable default for future use.

My intention here is to make a very thin configuration that does very little beyond the basic `config:base` preset that is included with Renovate. Individual users can customise their Renovate config to behave how they want, either using custom rules or using the semantic single-purpose presets in this repo.