### PR TITLE
Add more rules to central preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
   "extends": [
     "config:base",
     "github>CondeNast/renovate-config:groupMinorUpdates(dependencies)",
+    "github>CondeNast/renovate-config:groupCIDependencyUpdates",
+    "github>CondeNast/renovate-config:groupLinterUpdates",
     "github>CondeNast/renovate-config:groupNodeUpdates"
-  ]
+  ],
+  "dependencyDashboard": true,
+  "pinDigests": true
 }


### PR DESCRIPTION
This adds some more rules to the centralised preset that I consider to be "best practices" for dependency management.

Ensuring that docker digests are pinned was my original intention for this change, but I realised that having a Dependency Dashboard and some other groupings are also advisable in any context and I doubt anyone would object to these rules being in place.

Here's the full list of changes:
* Adds `CondeNast/renovate-config:groupCIDependencyUpdates` by default. This preset will currently just split CircleCI base images updates into a separate PR group.
* Adds `CondeNast/renovate-config:groupLinterUpdates` by default. This preset will split linters and code formatters into a separate PR group. These upgrades cause test failures often on minor upgrades so are worth splitting out separately for ease of maintenance, and also it means that the commit on the main branch explicitly mentions linters so maintainers can know it's not going to affect anything in production at a glance.
* Adds `"dependencyDashboard": true` (see [docs](https://docs.renovatebot.com/configuration-options/#dependencydashboard))
* Adds `"pinDigests": true` (see [docs](https://docs.renovatebot.com/configuration-options/#pindigests)). This will ask Renovate to pin the Docker digest SHA256 as well as the tag. It's important that we do this across our repos so that our builds are reproducible!