### PR TITLE
Fix grouping major versions

### DIFF
--- a/dontAutomergeTestFrameworks.json
+++ b/dontAutomergeTestFrameworks.json
@@ -18,7 +18,6 @@
       },
       "major": {
         "automerge": false,
-        "groupName": "test dependencies major version",
         "labels": ["{{arg0}}"]
       },
       "pin": {

--- a/groupCIDependencyUpdates.json
+++ b/groupCIDependencyUpdates.json
@@ -10,9 +10,6 @@
       "minor": {
         "groupName": "CI dependencies"
       },
-      "major": {
-        "groupName": "CI dependencies major version"
-      },
       "pin": {
         "groupName": "CI dependencies"
       },


### PR DESCRIPTION
Major dep upgrades should not be grouped by default.